### PR TITLE
Display previous booking notes for selected customers

### DIFF
--- a/resources/design/desktop/flat/template/appointmentpro/booking/new_booking.phtml
+++ b/resources/design/desktop/flat/template/appointmentpro/booking/new_booking.phtml
@@ -185,6 +185,18 @@ $gateways = (new Appointmentpro_Model_Gateways())->findAll(['value_id' => $value
                                 </div>
                               </div>
 
+                              <div class="form-group">
+                                <div class="col-sm-4">
+                                  <label class="control-label"><?php echo p__("appointmentpro", 'Previous Notes'); ?></label>
+                                </div>
+                                <div class="col-sm-8">
+                                  <div id="previous_notes_container" class="previous-notes-container">
+                                    <p id="previous_notes_message" class="text-muted"><?php echo p__("appointmentpro", 'Select a customer to view previous notes.'); ?></p>
+                                    <ul id="previous_notes_list" class="list-unstyled previous-notes-list"></ul>
+                                  </div>
+                                </div>
+                              </div>
+
 
                               <div class="row">
                                 <div class="col-md-12">
@@ -389,11 +401,19 @@ $gateways = (new Appointmentpro_Model_Gateways())->findAll(['value_id' => $value
               $('#customer_phone').val(data.customer.phone);
               $('#customer_id').val(data.customer.id);
 
+              if (typeof window.fetchCustomerNotes === 'function') {
+                window.fetchCustomerNotes(data.customer.id);
+              }
+
             } else {
               $('#customer_lastname').val('');
               $('#customer_firstname').val('');
               $('#customer_phone').val('');
               $('#customer_id').val(0);
+
+              if (typeof window.fetchCustomerNotes === 'function') {
+                window.fetchCustomerNotes(null);
+              }
             }
           },
           error: function() {
@@ -685,32 +705,158 @@ $gateways = (new Appointmentpro_Model_Gateways())->findAll(['value_id' => $value
     margin-right: 0px;
     margin-left: 0px;
   }
+
+  .previous-notes-container {
+    background-color: #f7f9fc;
+    border: 1px solid #e1e7ef;
+    border-radius: 4px;
+    padding: 10px 12px;
+    max-height: 180px;
+    overflow-y: auto;
+  }
+
+  .previous-notes-container.has-notes {
+    background-color: #ffffff;
+  }
+
+  .previous-notes-list {
+    margin: 0;
+    padding: 0;
+  }
+
+  .previous-note-item {
+    margin-bottom: 10px;
+  }
+
+  .previous-note-item:last-child {
+    margin-bottom: 0;
+  }
+
+  .previous-note-meta {
+    font-size: 12px;
+    color: #6c757d;
+  }
+
+  .previous-note-text {
+    font-size: 13px;
+    color: #2f353a;
+  }
 </style>
 <link href="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/css/select2.min.css" rel="stylesheet" />
 <script src="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/select2.min.js"></script>
 <script>
   $(document).ready(function() {
+    var previousNotesMessages = {
+      'default': '<?php echo addslashes(p__("appointmentpro", 'Select a customer to view previous notes.')); ?>',
+      'loading': '<?php echo addslashes(p__("appointmentpro", 'Loading previous notes...')); ?>',
+      'empty': '<?php echo addslashes(p__("appointmentpro", 'No previous notes found.')); ?>',
+      'error': '<?php echo addslashes(p__("appointmentpro", 'Unable to load previous notes.')); ?>'
+    };
+
+    var previousNotesSelectors = {
+      container: $('#previous_notes_container'),
+      message: $('#previous_notes_message'),
+      list: $('#previous_notes_list')
+    };
+
+    function resetPreviousNotes(message) {
+      previousNotesSelectors.container.removeClass('has-notes');
+      previousNotesSelectors.list.empty();
+      previousNotesSelectors.message.text(message).show();
+    }
+
+    function renderPreviousNotes(notes) {
+      previousNotesSelectors.list.empty();
+
+      if (!notes || !notes.length) {
+        resetPreviousNotes(previousNotesMessages.empty);
+        return;
+      }
+
+      previousNotesSelectors.container.addClass('has-notes');
+      previousNotesSelectors.message.hide();
+
+      $.each(notes, function(index, note) {
+        var $item = $('<li class="previous-note-item"></li>');
+        var metaParts = [];
+
+        if (note.appointment_date) {
+          metaParts.push(note.appointment_date);
+        }
+
+        if (note.service_name) {
+          metaParts.push(note.service_name);
+        }
+
+        if (note.status) {
+          metaParts.push(note.status);
+        }
+
+        if (!note.appointment_date && note.created_at) {
+          metaParts.push(note.created_at);
+        }
+
+        if (metaParts.length) {
+          $item.append('<div class="previous-note-meta">' + metaParts.join(' · ') + '</div>');
+        }
+
+        var $noteText = $('<div class="previous-note-text"></div>').text(note.note);
+        $item.append($noteText);
+        previousNotesSelectors.list.append($item);
+      });
+    }
+
+    function fetchCustomerNotes(customerId) {
+      if (!customerId) {
+        resetPreviousNotes(previousNotesMessages.default);
+        return;
+      }
+
+      previousNotesSelectors.container.removeClass('has-notes');
+      previousNotesSelectors.list.empty();
+      previousNotesSelectors.message.text(previousNotesMessages.loading).show();
+
+      $.ajax({
+        url: '/appointmentpro/booking/get-customer-notes',
+        type: 'POST',
+        dataType: 'json',
+        data: {
+          customer_id: customerId
+        },
+        success: function(response) {
+          if (response && response.success) {
+            renderPreviousNotes(response.notes || []);
+          } else {
+            resetPreviousNotes(previousNotesMessages.error);
+          }
+        },
+        error: function() {
+          resetPreviousNotes(previousNotesMessages.error);
+        }
+      });
+    }
+
     $('#customer_id').select2({
       ajax: {
-        url: '<?php echo $this->getUrl('appointmentpro/booking/get-customers') ?>', // Replace with your endpoint URL
+        url: '<?php echo $this->getUrl('appointmentpro/booking/get-customers') ?>',
         dataType: 'json',
         delay: 250,
         data: function(params) {
           return {
-            q: params.term || '' // search term, empty string for initial load
+            q: params.term || ''
           };
         },
         processResults: function(data) {
           return {
-            results: data.items // Adjust based on your API response structure
+            results: data.items
           };
         },
         cache: true
       },
-      minimumInputLength: 0, // Allow empty search term to fetch all customers
+      minimumInputLength: 0,
       placeholder: '<?php echo p__("appointmentpro", 'Select a customer'); ?>',
       allowClear: true,
-      width: '100%', // Set the width to 100%
+      width: '100%',
       language: {
         noResults: function() {
           return $('<div><?php echo p__("appointmentpro", 'No customers found.'); ?> <a class="btn btn-success btn-sm" rel="" href="#" id="add-new-customer"><?php echo p__("appointmentpro", 'Add new customer'); ?></a></div>');
@@ -718,18 +864,27 @@ $gateways = (new Appointmentpro_Model_Gateways())->findAll(['value_id' => $value
       }
     });
 
-    // Trigger an initial load to fetch all customers
     $('#customer_id').select2('open').select2('close');
+    resetPreviousNotes(previousNotesMessages.default);
 
     $('#customer_id').on('change', function() {
       var selectedId = $(this).val();
-      var selectedCustomer = $('#customer_id').select2('data')[0];
+      var select2Data = $('#customer_id').select2('data');
+      var selectedCustomer = (select2Data && select2Data.length) ? select2Data[0] : null;
+
       console.log('Selected customer ID:', selectedId);
       console.log('Selected customer object:', selectedCustomer);
-      $('#customer_email').val(selectedCustomer.email).trigger('input');
 
-      // You can add additional logic here to handle the selected customer object
+      if (selectedCustomer && selectedCustomer.email) {
+        $('#customer_email').val(selectedCustomer.email).trigger('input');
+      } else {
+        $('#customer_email').val('').trigger('input');
+      }
+
+      fetchCustomerNotes(selectedId);
     });
+
+    window.fetchCustomerNotes = fetchCustomerNotes;
   });
 
   let add_customer = {

--- a/resources/design/desktop/flat/template/appointmentpro/calendar/list.phtml
+++ b/resources/design/desktop/flat/template/appointmentpro/calendar/list.phtml
@@ -289,11 +289,47 @@ $minDate = date('d-m-Y', strtotime("-7 days"));
 		margin-bottom: 1rem;
 	}
 
-	#new_appointment_modal .form-group label {
-		margin-bottom: 0.5rem;
-		font-weight: 500;
-		color: #495057;
-	}
+        #new_appointment_modal .form-group label {
+                margin-bottom: 0.5rem;
+                font-weight: 500;
+                color: #495057;
+        }
+
+        .previous-notes-container {
+                background: #f7f9fc;
+                border: 1px solid #e1e7ef;
+                border-radius: 4px;
+                padding: 10px 12px;
+                max-height: 180px;
+                overflow-y: auto;
+        }
+
+        .previous-notes-container.has-notes {
+                background: #ffffff;
+        }
+
+        .previous-notes-list {
+                margin: 0;
+                padding: 0;
+        }
+
+        .previous-note-item {
+                margin-bottom: 10px;
+        }
+
+        .previous-note-item:last-child {
+                margin-bottom: 0;
+        }
+
+        .previous-note-meta {
+                font-size: 12px;
+                color: #6c757d;
+        }
+
+        .previous-note-text {
+                font-size: 13px;
+                color: #2f353a;
+        }
 </style>
 
 
@@ -430,12 +466,22 @@ $minDate = date('d-m-Y', strtotime("-7 days"));
 				</div>
 			</div>
 
-			<div class="form-row">
-				<div class="form-group col-md-12">
-					<label for="appointment_note"><?php echo p__("appointmentpro", "Note"); ?></label>
-					<textarea id="appointment_note" name="note" class="form-control" rows="3" placeholder="<?php echo p__("appointmentpro", "Enter a Note"); ?>"></textarea>
-				</div>
-			</div>
+                        <div class="form-row">
+                                <div class="form-group col-md-12">
+                                        <label for="appointment_note"><?php echo p__("appointmentpro", "Note"); ?></label>
+                                        <textarea id="appointment_note" name="note" class="form-control" rows="3" placeholder="<?php echo p__("appointmentpro", "Enter a Note"); ?>"></textarea>
+                                </div>
+                        </div>
+
+                        <div class="form-row">
+                                <div class="form-group col-md-12">
+                                        <label><?php echo p__("appointmentpro", "Previous Notes"); ?></label>
+                                        <div id="calendar_previous_notes" class="previous-notes-container">
+                                                <p id="calendar_previous_notes_message" class="text-muted"><?php echo p__("appointmentpro", "Select a customer to view previous notes."); ?></p>
+                                                <ul id="calendar_previous_notes_list" class="list-unstyled previous-notes-list"></ul>
+                                        </div>
+                                </div>
+                        </div>
 
 			<!-- Customer fields (initially hidden) -->
 			<div id="customer_fields" style="display: none;">
@@ -1299,10 +1345,102 @@ $minDate = date('d-m-Y', strtotime("-7 days"));
 		}
 
 		// Initialize custom customer search functionality
-		function initializeCustomerSearch() {
-			var searchTimeout;
-			var currentCustomers = [];
-			var selectedCustomer = null;
+                function initializeCustomerSearch() {
+                        var searchTimeout;
+                        var currentCustomers = [];
+                        var selectedCustomer = null;
+
+                        var previousNotesMessages = {
+                                'default': '<?php echo addslashes(p__("appointmentpro", 'Select a customer to view previous notes.')); ?>',
+                                'loading': '<?php echo addslashes(p__("appointmentpro", 'Loading previous notes...')); ?>',
+                                'empty': '<?php echo addslashes(p__("appointmentpro", 'No previous notes found.')); ?>',
+                                'error': '<?php echo addslashes(p__("appointmentpro", 'Unable to load previous notes.')); ?>'
+                        };
+
+                        var previousNotesSelectors = {
+                                container: $('#calendar_previous_notes'),
+                                message: $('#calendar_previous_notes_message'),
+                                list: $('#calendar_previous_notes_list')
+                        };
+
+                        function resetModalPreviousNotes(message) {
+                                previousNotesSelectors.container.removeClass('has-notes');
+                                previousNotesSelectors.list.empty();
+                                previousNotesSelectors.message.text(message).show();
+                        }
+
+                        function renderModalPreviousNotes(notes) {
+                                previousNotesSelectors.list.empty();
+
+                                if (!notes || !notes.length) {
+                                        resetModalPreviousNotes(previousNotesMessages.empty);
+                                        return;
+                                }
+
+                                previousNotesSelectors.container.addClass('has-notes');
+                                previousNotesSelectors.message.hide();
+
+                                $.each(notes, function(index, note) {
+                                        var $item = $('<li class="previous-note-item"></li>');
+                                        var metaParts = [];
+
+                                        if (note.appointment_date) {
+                                                metaParts.push(note.appointment_date);
+                                        }
+
+                                        if (note.service_name) {
+                                                metaParts.push(note.service_name);
+                                        }
+
+                                        if (note.status) {
+                                                metaParts.push(note.status);
+                                        }
+
+                                        if (!note.appointment_date && note.created_at) {
+                                                metaParts.push(note.created_at);
+                                        }
+
+                                        if (metaParts.length) {
+                                                $item.append('<div class="previous-note-meta">' + metaParts.join(' · ') + '</div>');
+                                        }
+
+                                        var $noteText = $('<div class="previous-note-text"></div>').text(note.note);
+                                        $item.append($noteText);
+                                        previousNotesSelectors.list.append($item);
+                                });
+                        }
+
+                        function fetchModalCustomerNotes(customerId) {
+                                if (!customerId) {
+                                        resetModalPreviousNotes(previousNotesMessages.default);
+                                        return;
+                                }
+
+                                previousNotesSelectors.container.removeClass('has-notes');
+                                previousNotesSelectors.list.empty();
+                                previousNotesSelectors.message.text(previousNotesMessages.loading).show();
+
+                                $.ajax({
+                                        url: '/appointmentpro/booking/get-customer-notes',
+                                        type: 'POST',
+                                        dataType: 'json',
+                                        data: {
+                                                customer_id: customerId
+                                        },
+                                        success: function(response) {
+                                                if (response && response.success) {
+                                                        renderModalPreviousNotes(response.notes || []);
+                                                } else {
+                                                        resetModalPreviousNotes(previousNotesMessages.error);
+                                                }
+                                        },
+                                        error: function() {
+                                                resetModalPreviousNotes(previousNotesMessages.error);
+                                        }
+                                });
+                        }
+
+                        resetModalPreviousNotes(previousNotesMessages.default);
 
 			// Handle input changes with debouncing
 			$('#customer_search').bind('keyup', function() {
@@ -1506,12 +1644,14 @@ $minDate = date('d-m-Y', strtotime("-7 days"));
 				$('#customer_firstname').val(firstName);
 				$('#customer_lastname').val(lastName);
 				$('#customer_email').val(email);
-				$('#customer_phone').val(phone);
+                                $('#customer_phone').val(phone);
 
-				// Show customer input fields so user can see/edit the selected customer data
-				$('.customer_inputs').show();
+                                // Show customer input fields so user can see/edit the selected customer data
+                                $('.customer_inputs').show();
 
-				console.log('Customer fields populated and shown');
+                                fetchModalCustomerNotes(customerId);
+
+                                console.log('Customer fields populated and shown');
 
 				// Verify fields are actually populated
 				setTimeout(function() {
@@ -1536,10 +1676,11 @@ $minDate = date('d-m-Y', strtotime("-7 days"));
 				$('#customer_firstname').val('');
 				$('#customer_lastname').val('');
 				$('#customer_email').val('');
-				$('#customer_phone').val('');
-				$('.customer_inputs').show();
-				console.log('New customer inputs shown');
-			}
+                                $('#customer_phone').val('');
+                                $('.customer_inputs').show();
+                                fetchModalCustomerNotes(null);
+                                console.log('New customer inputs shown');
+                        }
 
 			// Load initial customers when customer tab is opened
 			function loadInitialCustomers() {
@@ -2124,15 +2265,19 @@ $minDate = date('d-m-Y', strtotime("-7 days"));
 			$('#new_appointment_form')[0].reset();
 			$('#selected_customer_id').val('');
 			$('#customer_id').val(0); // Reset to 0 for new customer
-			$('#customer_search').val(''); // Reset custom customer search
-			$('#customer_search_results').hide(); // Hide search results
-			$('.customer_inputs').hide();
-			$('#service_price').text('-');
-			$('#service_duration').text('-');
+                        $('#customer_search').val(''); // Reset custom customer search
+                        $('#customer_search_results').hide(); // Hide search results
+                        $('.customer_inputs').hide();
+                        $('#service_price').text('-');
+                        $('#service_duration').text('-');
 
-			// Reset selected time slot display
-			$('#selected_start_time').text('-');
-			$('#selected_end_time').text('-');
+                        $('#calendar_previous_notes_list').empty();
+                        $('#calendar_previous_notes_message').text('<?php echo p__("appointmentpro", "Select a customer to view previous notes."); ?>').show();
+                        $('#calendar_previous_notes').removeClass('has-notes');
+
+                        // Reset selected time slot display
+                        $('#selected_start_time').text('-');
+                        $('#selected_end_time').text('-');
 
 			// Reset cascading dropdowns to initial state
 			$('#appointment_provider').attr('disabled', true).empty().append('<option value="">First select a location</option>');


### PR DESCRIPTION
## Summary
- add an admin endpoint that returns formatted historical notes for a selected customer
- surface previous booking notes in the desktop booking flow when the operator chooses a customer
- show prior customer notes in the calendar modal and reset the preview when switching customers

## Testing
- php -l controllers/BookingController.php

------
https://chatgpt.com/codex/tasks/task_e_68e3fb71f94c832da721cf9606811041