### PR TITLE
Default calendar to first location when none is selected

### DIFF
--- a/controllers/CalendarController.php
+++ b/controllers/CalendarController.php
@@ -16,9 +16,17 @@ class Appointmentpro_CalendarController extends Application_Controller_Default
         $value_id = (new Appointmentpro_Model_Appointmentpro())->getCurrentValueId();
         $bookingJson = [];
         $providersJson = [];
+        $location = [];
 
         $locations = (new Appointmentpro_Model_Location())
             ->findByValueId($value_id, []);
+
+        if (empty($location_id)) {
+            foreach ($locations as $defaultLocation) {
+                $location_id = $defaultLocation->getLocationId();
+                break;
+            }
+        }
 
         $setting = (new Appointmentpro_Model_Settings())->find($value_id, "value_id");
         $settingResult = $setting->getData();


### PR DESCRIPTION
### Motivation
- The calendar page required admins to manually select a location before appointments would load, and the controller could reference an undefined `$location` when no `location` parameter was present. 
- The change aims to auto-select a sensible default (the first configured location) so the calendar loads appointments immediately.

### Description
- Initialize `$location` and retrieve available locations via `Appointmentpro_Model_Location::findByValueId` in `controllers/CalendarController.php` to avoid undefined-variable issues. 
- When the `location` route parameter is empty, set `$location_id` to the first available location's `location_id` so the existing booking/provider loading flow runs automatically. 
- Preserve the existing explicit-location behavior when a `location` parameter is supplied and keep the remainder of the booking/provider processing unchanged. 
- Change is limited to `controllers/CalendarController.php` and only affects the default selection logic.

### Testing
- Ran PHP syntax check with `php -l controllers/CalendarController.php`, which reported no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d34bcee63c832d8cf2c73464033557)